### PR TITLE
Update usage docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,13 +20,13 @@ scope and avoid unrelated commits.
 1. To begin; [fork this project], clone your fork, and add our upstream.
    ```bash
    # Clone your fork of the repo into the current directory
-   git clone git@github.com:YOUR_USER/postcss-editor-styles.git
+   git clone git@github.com:YOUR_USER/postcss-editor-styles-wrapper.git
 
    # Navigate to the newly cloned directory
-   cd postcss-editor-styles
+   cd postcss-editor-styles-wrapper
 
    # Assign the original repo to a remote called "upstream"
-   git remote add upstream git@github.com:jonathantneal/postcss-editor-styles.git
+   git remote add upstream git@github.com:jonathantneal/postcss-editor-styles-wrapper.git
 
    # Install the tools necessary for testing
    npm install

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,13 +11,13 @@
 Add [PostCSS Editor Styles] to your project:
 
 ```bash
-npm install postcss-editor-styles --save-dev
+npm install postcss-editor-styles-wrapper --save-dev
 ```
 
 Use [PostCSS Editor Styles] to process your CSS:
 
 ```js
-const postcssEditorStyles = require("postcss-editor-styles");
+const postcssEditorStyles = require("postcss-editor-styles-wrapper");
 
 postcssEditorStyles.process(YOUR_CSS /*, processOptions, pluginOptions */);
 ```
@@ -26,7 +26,7 @@ Or use it as a [PostCSS] plugin:
 
 ```js
 const postcss = require("postcss");
-const postcssEditorStyles = require("postcss-editor-styles");
+const postcssEditorStyles = require("postcss-editor-styles-wrapper");
 
 postcss([postcssEditorStyles(/* pluginOptions */)]).process(
 	YOUR_CSS /*, processOptions */
@@ -44,7 +44,7 @@ npm install postcss-cli --save-dev
 Use [PostCSS Editor Styles] in your `postcss.config.js` configuration file:
 
 ```js
-const postcssEditorStyles = require("postcss-editor-styles");
+const postcssEditorStyles = require("postcss-editor-styles-wrapper");
 
 module.exports = {
 	plugins: [postcssEditorStyles(/* pluginOptions */)]
@@ -62,7 +62,7 @@ npm install postcss-loader --save-dev
 Use [PostCSS Editor Styles] in your Webpack configuration:
 
 ```js
-const postcssEditorStyles = require("postcss-editor-styles");
+const postcssEditorStyles = require("postcss-editor-styles-wrapper");
 
 module.exports = {
 	module: {
@@ -101,7 +101,7 @@ Use [React App Rewire PostCSS] and [PostCSS Editor Styles] in your
 
 ```js
 const reactAppRewirePostcss = require("react-app-rewire-postcss");
-const postcssEditorStyles = require("postcss-editor-styles");
+const postcssEditorStyles = require("postcss-editor-styles-wrapper");
 
 module.exports = config =>
 	reactAppRewirePostcss(config, {
@@ -121,7 +121,7 @@ Use [PostCSS Editor Styles] in your Gulpfile:
 
 ```js
 const postcss = require("gulp-postcss");
-const postcssEditorStyles = require("postcss-editor-styles");
+const postcssEditorStyles = require("postcss-editor-styles-wrapper");
 
 gulp.task("css", () =>
 	gulp
@@ -142,7 +142,7 @@ npm install grunt-postcss --save-dev
 Use [PostCSS Editor Styles] in your Gruntfile:
 
 ```js
-const postcssEditorStyles = require("postcss-editor-styles");
+const postcssEditorStyles = require("postcss-editor-styles-wrapper");
 
 grunt.loadNpmTasks("grunt-postcss");
 

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ button {          /* scoped and negated */
 Add [PostCSS Editor Styles Wrapper] to your project:
 
 ```bash
-npm install postcss-editor-styles --save-dev
+npm install postcss-editor-styles-wrapper --save-dev
 ```
 
 Use [PostCSS Editor Styles] to process your CSS:
 
 ```js
-const postcssEditorStyles = require("postcss-editor-styles");
+const postcssEditorStyles = require("postcss-editor-styles-wrapper");
 
 postcssEditorStyles.process(YOUR_CSS /*, processOptions, pluginOptions */);
 ```
@@ -68,7 +68,7 @@ Or use it as a [PostCSS] plugin:
 
 ```js
 const postcss = require("postcss");
-const postcssEditorStyles = require("postcss-editor-styles");
+const postcssEditorStyles = require("postcss-editor-styles-wrapper");
 
 postcss([postcssEditorStyles(/* pluginOptions */)]).process(
   YOUR_CSS /*, processOptions */


### PR DESCRIPTION
While using the package I ran into a bit of confusion and in order to use the correct plugin I needed to use `postcss-editor-styles-wrapper` as the plugin name (which is the name in `package.json`).

These code changes hopefully make it clear on how to use this forked version, and to avoid confusion to other potential users and I believe use in 10up-toolkit in the future.